### PR TITLE
gccでのmake

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -1,39 +1,33 @@
-.SUFFIXES: 
 .SUFFIXES: .o .c .cc .cpp .h .d
 
-CC       := clang
-CXX      := clang++
-SED      := sed #@SED@
-MV       := mv #@MV@
-AR       := ar #@AR@
-RM	 := rm #@RM@
-LN       := ln #@LN@
+CC	:= clang
+CXX	:= clang++
+SED	:= sed
+MV	:= mv
+AR	:= ar
+RM	:= rm
+LN	:= ln
 
 LIBS += -lpthread
 # LIBS += -lpthread -luuid
 
 UNAME := $(shell uname)
 
-LIBS_STATIC += -lboost_regex
 MATHPATH ?= /usr/local/Wolfram/Mathematica/11.3
 
 ifeq ($(UNAME),Linux)
-LIBS_STATIC += -lboost_thread
+	INCLUDES += -I$(MATHPATH)/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions/
+	LDFLAGS	 += -L$(MATHPATH)/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions/
 
-INCLUDES += -I$(MATHPATH)/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions/
-LDFLAGS	 += -L$(MATHPATH)/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions/
-
-CXX_OPT  += -Wall -std=c++2a -luuid -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
-# CXX_OPT  += -Wall -std=c++17 -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
+	CXX_OPT  += -Wall -std=c++2a -luuid -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
+	# CXX_OPT  += -Wall -std=c++17 -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
 endif
 ifeq ($(UNAME),Darwin)
-LIBS_STATIC += -lboost_thread-mt
+	INCLUDES += -I/Applications/Mathematica\ 2.app/Contents/SystemFiles/Links/WSTP/DeveloperKit/MacOSX-x86-64/CompilerAdditions/
+	INCLUDES += `python3-config --includes`
+	LDFLAGS  += -L/Applications/Mathematica\ 2.app/Contents/SystemFiles/Links/WSTP/DeveloperKit/MacOSX-x86-64/CompilerAdditions/
 
-INCLUDES += -I/Applications/Mathematica\ 2.app/Contents/SystemFiles/Links/WSTP/DeveloperKit/MacOSX-x86-64/CompilerAdditions/
-INCLUDES += `python3-config --includes`
-LDFLAGS  += -L/Applications/Mathematica\ 2.app/Contents/SystemFiles/Links/WSTP/DeveloperKit/MacOSX-x86-64/CompilerAdditions/
-
-CXX_OPT  += -Wall -std=c++2a -framework Foundation -Wno-unused-command-line-argument -Wno-unused-variable
+	CXX_OPT  += -Wall -std=c++2a -framework Foundation -Wno-unused-command-line-argument -Wno-unused-variable
 endif
 
 ARFLAGS  := cru
@@ -42,8 +36,8 @@ CXXFLAGS += $(INCLUDES) $(DEFINES) $(CXX_OPT)
 SRC_DIR  += .
 SRC      += $(foreach dir,$(SRC_DIR), $(wildcard $(dir)/*.c) $(wildcard $(dir)/*.cc) $(wildcard $(dir)/*.cpp)) 
 OBJECT   := $(subst .c,.o,$(filter %.c,$(SRC))) \
-	    $(subst .cc,.o,$(filter %.cc,$(SRC))) \
-			$(subst .cpp,.o,$(filter %.cpp,$(SRC)))
+						$(subst .cc,.o,$(filter %.cc,$(SRC))) \
+						$(subst .cpp,.o,$(filter %.cpp,$(SRC)))
 DEP_FILE := $(OBJECT:.o=.d)
 COMPILE_COMMANDS_SRC := $(OBJECT:.o=.o.json)
 
@@ -66,7 +60,7 @@ else
 endif
 
 ifneq "$(MAKECMDGOALS)" "clean"
--include $(DEP_FILE)
+	-include $(DEP_FILE)
 endif
 
 .c.o:

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -8,19 +8,18 @@ AR	:= ar
 RM	:= rm
 LN	:= ln
 
-LIBS += -lpthread
-# LIBS += -lpthread -luuid
-
 UNAME := $(shell uname)
 
 MATHPATH ?= /usr/local/Wolfram/Mathematica/11.3
 
 ifeq ($(UNAME),Linux)
+	LIBS += -luuid
+
 	INCLUDES += -I$(MATHPATH)/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions/
 	LDFLAGS	 += -L$(MATHPATH)/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions/
 
-	CXX_OPT  += -Wall -std=c++2a -luuid -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
-	# CXX_OPT  += -Wall -std=c++17 -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
+	# CXX_OPT  += -Wall -std=c++2a -luuid -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
+	CXX_OPT  += -Wall -std=c++17 -O -Wno-register -Wno-unused-command-line-argument -Wno-unused-variable
 endif
 ifeq ($(UNAME),Darwin)
 	INCLUDES += -I/Applications/Mathematica\ 2.app/Contents/SystemFiles/Links/WSTP/DeveloperKit/MacOSX-x86-64/CompilerAdditions/
@@ -55,8 +54,8 @@ ifeq ($(MAKE_TYPE),library)
 else ifeq ($(UNAME),Darwin)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) $(LIBS) $(LIBS_STATIC)
 else
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS)
-	# $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS) $(INCLUDES)
+	# $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS) $(INCLUDES)
 endif
 
 ifneq "$(MAKECMDGOALS)" "clean"

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -45,16 +45,14 @@ OBJECT   := $(subst .c,.o,$(filter %.c,$(SRC))) \
 	    $(subst .cc,.o,$(filter %.cc,$(SRC))) \
 			$(subst .cpp,.o,$(filter %.cpp,$(SRC)))
 DEP_FILE := $(OBJECT:.o=.d)
-
 COMPILE_COMMANDS_SRC := $(OBJECT:.o=.o.json)
-COMPILE_COMMANDS_JSON := compile_commands.json
 
 .PHONY : all
-all: $(DEP_PROJECTS) $(TARGET) $(COMPILE_COMMANDS_JSON)
+all: $(DEP_PROJECTS) $(TARGET)
 
 .PHONY : clean
 clean:
-	-$(RM) -fr $(TARGET) $(OBJECT) $(DEP_FILE) $(CLEAN_FILES) $(COMPILE_COMMANDS_SRC) $(COMPILE_COMMANDS_JSON)
+	-$(RM) -fr $(TARGET) $(OBJECT) $(DEP_FILE) $(CLEAN_FILES) $(COMPILE_COMMANDS_SRC)
 
 $(TARGET): $(DEP_OBJECTS) $(OBJECT)
 ifeq ($(MAKE_TYPE),library)
@@ -67,11 +65,6 @@ else
 	# $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS) $(INCLUDES)
 endif
 
-$(COMPILE_COMMANDS_JSON): $(OBJECT)
-	cat $(COMPILE_COMMANDS_SRC) |  $(SED) -e '1s/^/[\n/' -e '$$s/,$$/\n]/' > $(COMPILE_COMMANDS_JSON)
-#$(DEP_OBJECTS):
-#	$(MAKE) --directory=$(dir $@)
-
 ifneq "$(MAKECMDGOALS)" "clean"
 -include $(DEP_FILE)
 endif
@@ -80,8 +73,7 @@ endif
 	$(CC) $(CXXFLAGS) -c -o $@ $<
 
 .cc.o .cpp.o:
-	$(CXX) $(CXXFLAGS) -MJ $@.json -c -o $@ $<
-	# $(CXX) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 .c.d .cc.d .cpp.d:
 	$(CXX) $(CXXFLAGS) $(TARGET_ARCH) -M $< | \

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -52,7 +52,8 @@ ifeq ($(MAKE_TYPE),library)
 	$(AR) $(ARFLAGS) $@ $(OBJECT)
 	ranlib $@
 else ifeq ($(UNAME),Darwin)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) $(LIBS) $(LIBS_STATIC)
+	# $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) $(LIBS) $(LIBS_STATIC)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) $(LIBS) $(LIBS_STATIC) $(INCLUDES)
 else
 	# $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECT) -Wl,-Bstatic $(LIBS_STATIC) -Wl,-Bdynamic $(LIBS) $(INCLUDES)

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -60,7 +60,7 @@ else
 endif
 
 ifneq "$(MAKECMDGOALS)" "clean"
-	-include $(DEP_FILE)
+-include $(DEP_FILE)
 endif
 
 .c.o:

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -411,7 +411,7 @@ int Backend::send_variable_map(const variable_map_t &vm, const VariableForm &vf,
       send_variable(var, vf);
       send_value(range.get_unique_value(), vf);
     } else {
-      for (uint i = 0; i < range.get_lower_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
         const value_range_t::bound_t &bnd = range.get_lower_bound(i);
         if (bnd.include_bound) {
           link_->put_converted_function("GreaterEqual", 2);
@@ -422,7 +422,7 @@ int Backend::send_variable_map(const variable_map_t &vm, const VariableForm &vf,
         send_value(bnd.value, vf);
       }
 
-      for (uint i = 0; i < range.get_upper_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
         const value_range_t::bound_t &bnd = range.get_upper_bound(i);
         if (bnd.include_bound) {
           link_->put_converted_function("LessEqual", 2);
@@ -469,7 +469,7 @@ int Backend::send_parameter_map(const parameter_map_t &parameter_map) {
                            param.get_phase_id());
       send_value(value, VF_PREV);
     } else {
-      for (uint i = 0; i < it->second.get_lower_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < it->second.get_lower_cnt(); i++) {
         const value_range_t::bound_t &bnd = it->second.get_lower_bound(i);
         const value_t &value = bnd.value;
         const parameter_t &param = it->first;
@@ -483,7 +483,7 @@ int Backend::send_parameter_map(const parameter_map_t &parameter_map) {
                              param.get_phase_id());
         send_value(value, VF_PREV);
       }
-      for (uint i = 0; i < it->second.get_upper_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < it->second.get_upper_cnt(); i++) {
         const value_range_t::bound_t &bnd = it->second.get_upper_bound(i);
         const value_t &value = bnd.value;
         const parameter_t &param = it->first;

--- a/src/io/JsonWriter.cpp
+++ b/src/io/JsonWriter.cpp
@@ -104,7 +104,7 @@ value JsonWriter::for_range(const value_range_t &range) {
     range_object["unique_value"] = value(range.get_unique_value().get_string());
   } else {
     picojson::array lbs;
-    for (uint i = 0; i < range.get_lower_cnt(); i++) {
+    for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
       const value_range_t::bound_t &bound = range.get_lower_bound(i);
       object lb;
       lb["value"] = value(bound.value.get_string());
@@ -114,7 +114,7 @@ value JsonWriter::for_range(const value_range_t &range) {
     range_object["lower_bounds"] = value(lbs);
 
     picojson::array ubs;
-    for (uint i = 0; i < range.get_upper_cnt(); i++) {
+    for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
       const value_range_t::bound_t &bound = range.get_upper_bound(i);
       object ub;
       ub["value"] = value(bound.value.get_string());
@@ -177,7 +177,7 @@ value JsonWriter::for_range_diff(const value_range_t &range) {
     range_object["unique_value"] = value(ret.get_string());
   } else {
     picojson::array lbs;
-    for (uint i = 0; i < range.get_lower_cnt(); i++) {
+    for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
       const value_range_t::bound_t &bound = range.get_lower_bound(i);
       object lb;
       tmp = bound.value;
@@ -189,7 +189,7 @@ value JsonWriter::for_range_diff(const value_range_t &range) {
     range_object["lower_bounds"] = value(lbs);
 
     picojson::array ubs;
-    for (uint i = 0; i < range.get_upper_cnt(); i++) {
+    for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
       const value_range_t::bound_t &bound = range.get_upper_bound(i);
       object ub;
       tmp = bound.value;

--- a/src/simulator/EpsilonMode.cpp
+++ b/src/simulator/EpsilonMode.cpp
@@ -37,7 +37,7 @@ void hydla::simulator::cut_high_order_epsilon(Backend *backend_,
                      &diff_cnt, &value_ret);
       phase->variable_map[var] = value_ret;
     } else {
-      for (uint i = 0; i < range.get_lower_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
         ValueRange::bound_t bd = range.get_lower_bound(i);
         value_t val = bd.value;
         value_t ret;
@@ -45,7 +45,7 @@ void hydla::simulator::cut_high_order_epsilon(Backend *backend_,
                        &par, &diff_cnt, &ret);
         range.set_lower_bound(ret, bd.include_bound);
       }
-      for (uint i = 0; i < range.get_upper_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
         ValueRange::bound_t bd = range.get_upper_bound(i);
         value_t val = bd.value;
         value_t ret;

--- a/src/simulator/ValueModifier.cpp
+++ b/src/simulator/ValueModifier.cpp
@@ -26,12 +26,12 @@ ValueRange ValueModifier::apply_function(const std::string &function,
       result_range.set_unique_value(
           apply_function(function, time, range.get_unique_value()));
     } else {
-      for (uint i = 0; i < range.get_lower_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
         ValueRange::bound_t bd = range.get_lower_bound(i);
         result_range.add_lower_bound(apply_function(function, time, bd.value),
                                      bd.include_bound);
       }
-      for (uint i = 0; i < range.get_upper_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
 
         ValueRange::bound_t bd = range.get_upper_bound(i);
         result_range.add_upper_bound(apply_function(function, time, bd.value),
@@ -69,12 +69,12 @@ ValueRange ValueModifier::apply_function(const std::string &function,
       result_range.set_unique_value(
           apply_function(function, range.get_unique_value(), fmt));
     } else {
-      for (uint i = 0; i < range.get_lower_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
         ValueRange::bound_t bd = range.get_lower_bound(i);
         result_range.add_lower_bound(apply_function(function, bd.value, fmt),
                                      bd.include_bound);
       }
-      for (uint i = 0; i < range.get_upper_cnt(); i++) {
+      for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
 
         ValueRange::bound_t bd = range.get_upper_bound(i);
         result_range.add_upper_bound(apply_function(function, bd.value, fmt),

--- a/src/simulator/VariableReplacer.cpp
+++ b/src/simulator/VariableReplacer.cpp
@@ -32,12 +32,12 @@ void VariableReplacer::replace_range(ValueRange &range) {
     value_t val = range.get_unique_value();
     replace_value(val);
   } else {
-    for (uint i = 0; i < range.get_lower_cnt(); i++) {
+    for (ValueRange::uint i = 0; i < range.get_lower_cnt(); i++) {
       value_t val = range.get_lower_bound(i).value;
       replace_value(val);
       range.set_lower_bound(val, range.get_lower_bound(i).include_bound);
     }
-    for (uint i = 0; i < range.get_upper_cnt(); i++) {
+    for (ValueRange::uint i = 0; i < range.get_upper_cnt(); i++) {
       value_t val = range.get_upper_bound(i).value;
       replace_value(val);
       range.set_upper_bound(val, range.get_upper_bound(i).include_bound);
@@ -80,7 +80,7 @@ void VariableReplacer::visit(
 void VariableReplacer::visit(
     std::shared_ptr<hydla::symbolic_expression::Parameter> parameter) {
   if (v_to_par) {
-    new_child_ = symbolic_expression::node_sptr(parameter);
+    new_child_ = static_pointer_cast<symbolic_expression::Node>(parameter);
   }
 }
 

--- a/src/simulator/VariableReplacer.h
+++ b/src/simulator/VariableReplacer.h
@@ -65,7 +65,7 @@ public:
 
 private:
   int differential_cnt;
-  uint replace_cnt;
+  unsigned int replace_cnt;
   const variable_map_t &variable_map;
   const bool v_to_par;
 

--- a/src/utility/Utility.cpp
+++ b/src/utility/Utility.cpp
@@ -49,10 +49,10 @@ string replace(string original, const string &substr, const string &dest) {
 
 string remove_comment(string &src) {
   std::string comment;
-  for (uint i = 0; i < src.length(); i++) {
+  for (unsigned int i = 0; i < src.length(); i++) {
     if (src[i] == '/' && (i + 1) < src.length() && src[i + 1] == '/') {
       i += 2;
-      uint start_point = i;
+      unsigned int start_point = i;
       while (i < src.length() && src[i] != '\n')
         i++;
       comment += src.substr(start_point, i - start_point);
@@ -61,7 +61,7 @@ string remove_comment(string &src) {
       i = start_point - 2;
     } else if (src[i] == '/' && (i + 1) < src.length() && src[i + 1] == '*') {
       i += 2;
-      uint start_point = i;
+      unsigned int start_point = i;
       while (i < src.length() &&
              !(src[i] == '*' && (i + 1) < src.length() && src[i + 1] == '/'))
         i++;


### PR DESCRIPTION
## 内容
Linux, Macでclangでのmakeができるようにしたまま，Linuxでgccでのmakeができるようにする

## テスト
以下でgccでのmakeを確認
- rollot
  - Ubuntu 18.04.3 LTS
  - gcc version 7.4.0
  - Boost 1.65.1
  - Mathematica 11.3.0 Kernel for Linux x86 (64-bit)
- pecorino
  - 同上

以下でclangでのmakeを確認
- rollot
  - clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)
- pecorino
  - 同上
- 山田私物のMac
  - Catalina 10.15.3（19D76）
  - Apple clang version 11.0.0 (clang-1100.0.33.17)
  - Boost 1.72.0
  - Mathematica 12.0.0 Kernel for Mac OS X x86 (64-bit)
- 研究室から持ち帰ったMac（mojave, Mathematicaはライセンスサーバ用）by 上田先生