### PR TITLE
refs #12 add argument check of DSolve

### DIFF
--- a/src/backend/mathematica/math_source/math_source.m
+++ b/src/backend/mathematica/math_source/math_source.m
@@ -1044,9 +1044,14 @@ Module[
   解けたものが解である*)
   For[i = Length[ini], i >= 0, i--,
     inis = Subsets[ini, {i}];
+    debugPrint[Length[inis]];
     For[j = 1, j <= Length[inis], j++,
       (*simplePrint[Union[expr, inis[[j]]]];*)
       (*simplePrint[tVars];*)
+      If[
+        Length[tVars] == 0,
+        Continue[]
+      ];
       sol = Quiet[
         Check[
           DSolve[Union[expr, inis[[j]]], tVars, t],
@@ -1055,6 +1060,7 @@ Module[
         ],
         {DSolve::overdet, DSolve::bvimp, DSolve::bvnul, Solve::svars, PolynomialGCD::lrgexp}
       ];
+      debugPrint[sol == overConstrained];
       If[Length[sol] > 0,
         Break[]
       ]
@@ -1087,14 +1093,19 @@ Module[
   (*simplePrint[expr];*)
   (*simplePrint[vars];*)
   (*一般解を求める*)
-  solwithconstant = Quiet[
-    Check[
-      DSolve[expr, vars, t],
-          overConstrained,
-      {DSolve::overdet, DSolve::bvimp}
-    ],
-    {DSolve::overdet, DSolve::bvimp, DSolve::bvnul, Solve::svars, PolynomialGCD::lrgexp}
+  If[
+    Length[vars] == 0,
+    solwithConstant = overConstrained,
+    solwithconstant = Quiet[
+      Check[
+        DSolve[expr, vars, t],
+            overConstrained,
+        {DSolve::overdet, DSolve::bvimp}
+      ],
+      {DSolve::overdet, DSolve::bvimp, DSolve::bvnul, Solve::svars, PolynomialGCD::lrgexp}
+    ];
   ];
+
   (*simplePrint[solwithconstant];*)
   For[i = 1, i <= Length[solwithconstant], i++,
     ini = {};


### PR DESCRIPTION
# 概要
issue #12 参照
# 実装
solveByDSolve 内で DSolve を叩く前に引数チェックした（コードを見た方が早い）
# テスト
Mathematica 12.2 の乗ったマシンで ``` make test ``` を叩いて成功することを確認した