### PR TITLE
#9 fix rational number initialization bug

### DIFF
--- a/src/backend/mathematica/math_source/math_source.m
+++ b/src/backend/mathematica/math_source/math_source.m
@@ -208,10 +208,18 @@ Module[
     If[Length[newVars] == 1,
       processedVars = Append[processedVars, newVars[[1]] ];
       simplePrint[listToProcess[[i]], newVars[[1]] ];
-      tmpCons = Quiet[Check[If[listToProcess[[i]] =!= newVars[[1]],
-        newVars[[1]] == Solve[listToProcess[[i]], newVars[[1]]][[1, 1, 2]],
-        listToProcess[[i]]
-      ], listToProcess[[i]] ] ];
+      tmpCons = 
+        Quiet[
+          Check[
+            If[
+              listToProcess[[i]] =!= newVars[[1]],
+              newVars[[1]] == Solve[listToProcess[[i]], newVars[[1]]][[1, 1, 2]],
+              listToProcess[[i]]
+            ],
+            (* Issue #9: Solve generates message for inequalities, so handle them with Reduce *)
+            Reduce[listToProcess[[i]], newVars[[1]] ] 
+          ] 
+        ];
       If[Head[tmpCons] === ConditionalExpression, tmpCons = listToProcess[[i]] ]; (* revert tmpCons *)
       simplePrint[tmpCons];
       If[!MemberQ[{Unequal, Less, LessEqual, Equal, Greater, GreaterEqual}, tmpCons], succeeded = false];


### PR DESCRIPTION
有理数が絡む初期化のバグを修正.
x > 0.5 などの式は addConstraint 内の SImplify によって 2x > 1 のような形に一度変形される.
最終的には x について解きたいので, tryToTransformConstraint 内で Reduce を使用した.