### PR TITLE
#10 fix init bug due to variable's name

### DIFF
--- a/.github/workflows/build-on-ubuntu.yaml
+++ b/.github/workflows/build-on-ubuntu.yaml
@@ -19,7 +19,7 @@ jobs:
         sudo ln -s libuuid.so.1.3.0 libuuid.so
     - name: build
       run: |
-        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.0 CC=clang CXX=clang++
+        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.1 CC=clang CXX=clang++
   ubuntu18_04-gcc7_5_0-python3_6_9:
     runs-on: ubuntu-18.04
     steps:
@@ -31,7 +31,7 @@ jobs:
         sudo ln -s libuuid.so.1.3.0 libuuid.so
     - name: build
       run: |
-        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.0 CC=gcc CXX=g++
+        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.1 CC=gcc CXX=g++
   ubuntu20_04-clang10_0_0-python3_8_5:
     runs-on: ubuntu-20.04
     steps:
@@ -39,7 +39,7 @@ jobs:
     - uses: ./.github/actions/setup-ubuntu
     - name: build
       run: |
-        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.0 CC=clang CXX=clang++
+        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.1 CC=clang CXX=clang++
   ubuntu20_04-gcc9_3_0-python3_8_5:
     runs-on: ubuntu-20.04
     steps:
@@ -47,4 +47,4 @@ jobs:
     - uses: ./.github/actions/setup-ubuntu
     - name: build
       run: |
-        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.0 CC=gcc CXX=g++
+        make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/13.1 CC=gcc CXX=g++

--- a/src/backend/mathematica/math_source/load_first/common.m
+++ b/src/backend/mathematica/math_source/load_first/common.m
@@ -283,3 +283,23 @@ solveOverRorC[consToSolve_,vars_] :=
   If[optSolveOverReals === True, Solve[consToSolve,vars,Reals], Solve[consToSolve,vars]]
 
 derivativePrefix = "d";
+
+swapExpr[expr_] := Module[
+  {newLHS = expr[[2]], newRHS = expr[[1]], ret = expr},
+  If[
+    Head[expr] == Equal, ret = Equal[newLHS, newRHS]
+  ];
+  If[
+    Head[expr] == LessEqual, ret = GreaterEqual[newLHS, newRHS]
+  ];
+  If[
+    Head[expr] == Less, ret = Greater[newLHS, newRHS]
+  ];
+  If[
+    Head[expr] == GreaterEqual, ret = LessEqual[newLHS, newRHS]
+  ];
+  If[
+    Head[expr] == Greater, ret = Less[newLHS, newRHS]
+  ];
+  ret
+];

--- a/src/backend/mathematica/math_source/math_source.m
+++ b/src/backend/mathematica/math_source/math_source.m
@@ -217,12 +217,13 @@ Module[
               listToProcess[[i]]
             ],
             (* Issue #9: Solve generates message for inequalities, so handle them with Reduce *)
-            Reduce[listToProcess[[i]], newVars[[1]] ] 
+            Reduce[listToProcess[[i]], newVars[[1]], Reals ] 
           ] 
         ];
       If[Head[tmpCons] === ConditionalExpression, tmpCons = listToProcess[[i]] ]; (* revert tmpCons *)
       simplePrint[tmpCons];
       If[!MemberQ[{Unequal, Less, LessEqual, Equal, Greater, GreaterEqual}, tmpCons], succeeded = false];
+      If[MemberQ[getVariablesWithDerivatives[tmpCons[[2]]], newVars[[1]]], tmpCons = swapExpr[tmpCons] ];
       resultCons = resultCons && tmpCons;
       listToProcess = Drop[listToProcess, {i}];
       i = 0;


### PR DESCRIPTION
`math_source.m` 内の `tryToTransformConstraints` において, 今計算対象の変数 `newVars[[1]]` が左辺に来ていないときに式の両辺をスワップする `e.g. a <= b -> b >= a` 処理を追加した. この処理は Solve もしくは Reduce によって newVars[[1]] について解かれた状態で行われる.

#9 で追加した Reduce 処理は, `Reduce[ua >= ub, ua]` とすると `Elements[ua, Reals]` なるものを追加するがそれが後の処理に影響してうまく動かなかったので, ひとまずこれは Reduce の第三引数に Reals を明示的に指定することで消した. これを Complex にしたければその時に考える.