### PR TITLE
add/fix breakline

### DIFF
--- a/src/backend/mathematica/MathematicaLink.cpp
+++ b/src/backend/mathematica/MathematicaLink.cpp
@@ -132,11 +132,25 @@ bool MathematicaLink::receive_to_return_packet() {
       str = utility::replace(str, "\\011", "\t");
       if (input_print_.empty()) {
         input_print_ = str;
-        if (trace)
+        if (trace){
+          for(int i = str.size(); i > 0; i--){
+            if(str[i-1] == '\n'){
+              str[i-1] = ' ';    
+              break;
+            }
+          }
           HYDLA_LOGGER_DEBUG("input: \n", str);
+        }
       } else {
-        if (trace)
+        if (trace){
+          for(int i = str.size(); i > 0; i--){
+            if(str[i-1] == '\n'){
+              str[i-1] = ' ';
+              break;
+            }    
+          }
           HYDLA_LOGGER_DEBUG_INTERNAL("trace: ", str);
+        }
         debug_print_ += str + "\n";
       }
       break;

--- a/src/common/Logger.h
+++ b/src/common/Logger.h
@@ -56,7 +56,8 @@ public:
   template <typename... As> static void debug_write(const As &... args) {
     hydla::logger::Logger &i = hydla::logger::Logger::instance();
     if (i.valid_level(LogLevel::Debug)) {
-      i.debug_ << i.format(args...) << std::endl;
+      i.debug_ << i.format(args...) << "\n";
+      // i.debug_ << i.format(args...) << std::endl;
     }
   }
 
@@ -115,8 +116,7 @@ public:
           << timer.get_elapsed_us() << "[us]<br><br>" << std::endl;
     } else {
       if (i.valid_level(LogLevel::Debug)) {
-        i.debug_ << "timer elapsed: " << timer.get_elapsed_us() << "[us]"
-                 << std::endl;
+        i.debug_ << "timer elapsed: " << timer.get_elapsed_us() << "[us]\n\n";
       }
     }
   }
@@ -250,6 +250,7 @@ private:
     if (new_str.find("trace") != std::string::npos && new_str.find("publicRet") == std::string::npos) {
       new_str = "<span style=\"padding-left: 1em;\">" + new_str + " </span>";
     }
+    new_str.append("<br>");
 
     return new_str;
   }


### PR DESCRIPTION
html で function などの改行が入れないと不自然に長い一行ができてしまうことに気付いて直した & テキスト出力の改行を追加した.
html 出力の時は endl ではなく \n がよい
Before
![image](https://user-images.githubusercontent.com/45731368/220061259-29e6055d-90b6-43a0-8149-9f85bb2bf9fd.png)

After
![image](https://user-images.githubusercontent.com/45731368/220061726-d8cf05fd-1fa0-42db-a68d-5e3cd9fb89d5.png)
