### PR TITLE
fix tm option for master

### DIFF
--- a/src/core/ProgramOptions.cpp
+++ b/src/core/ProgramOptions.cpp
@@ -251,7 +251,9 @@ void ProgramOptions::init_descriptions() {
                                 ("dsolve", value<int>()->default_value(0), "")
 
                                     ("tm",
-                                     value<std::string>()->default_value("n"),
+                                     value<std::vector<std::string>>()
+                                      ->multitoken()
+                                      ->default_value(std::vector<string>{"n"}, ""),
                                      "")
 
                                         ("csv",

--- a/src/core/symbolic_simulate.cpp
+++ b/src/core/symbolic_simulate.cpp
@@ -114,19 +114,22 @@ void output_result(Simulator &ss, Opts &opts) {
     writer.write(*simulator_, of_name, input_file_name + "_diff");
   }
 
-  if (cmdline_options.get<std::vector<string>>("tm").at(0) == "s") {
-    hydla::io::StdProfilePrinter().print_profile(ss.get_profile());
-  } else if (cmdline_options.get<std::vector<string>>("tm").at(0) == "c") {
-    std::string csv_name = cmdline_options.get<std::vector<string>>("tm").at(1);
-    if (csv_name == "") {
-      hydla::io::CsvProfilePrinter().print_profile(ss.get_profile());
-    } else {
-      std::ofstream ofs;
-      ofs.open(csv_name.c_str());
-      hydla::io::CsvProfilePrinter(ofs).print_profile(ss.get_profile());
-      ofs.close();
+  if (not is_master()) {
+    if (cmdline_options.get<std::vector<string>>("tm").at(0) == "s") {
+      hydla::io::StdProfilePrinter().print_profile(ss.get_profile());
+    } else if (cmdline_options.get<std::vector<string>>("tm").at(0) == "c") {
+      std::string csv_name = cmdline_options.get<std::vector<string>>("tm").at(1);
+      if (csv_name == "") {
+        hydla::io::CsvProfilePrinter().print_profile(ss.get_profile());
+      } else {
+        std::ofstream ofs;
+        ofs.open(csv_name.c_str());
+        hydla::io::CsvProfilePrinter(ofs).print_profile(ss.get_profile());
+        ofs.close();
+      }
     }
   }
+  
 }
 
 void trim_front_and_behind_space(std::string &buffer) {


### PR DESCRIPTION
```--tm``` オプションが ```master``` に存在しないことで発生していた ```symbolic_simulate.cpp``` の ```output_result()``` 内でのキャストエラーの解消
```ProgramOption.cpp``` 内の ```is_master()``` を用いたチェックを噛ませた