### PR TITLE
Convert function names to lowercase in AffineTreeVisitor and IntervalTreeVisitor

### DIFF
--- a/src/interval/AffineTreeVisitor.cpp
+++ b/src/interval/AffineTreeVisitor.cpp
@@ -192,6 +192,7 @@ void AffineTreeVisitor::visit(
     std::shared_ptr<symbolic_expression::Function> node) {
   HYDLA_LOGGER_NODE_VISIT;
   std::string name = node->get_name();
+  std::transform(name.begin(), name.end(), name.begin(), ::tolower);
   if (name == "log") {
     if (node->get_arguments_size() != 1)
       invalid_node(*node);

--- a/src/interval/IntervalTreeVisitor.cpp
+++ b/src/interval/IntervalTreeVisitor.cpp
@@ -158,6 +158,7 @@ void IntervalTreeVisitor::visit(
 void IntervalTreeVisitor::visit(
     std::shared_ptr<symbolic_expression::Function> node) {
   std::string name = node->get_name();
+  std::transform(name.begin(), name.end(), name.begin(), ::tolower);
   itvd arg;
   if (name == "sin") {
     if (node->get_arguments_size() != 1) {


### PR DESCRIPTION
Functionノードの関数名が、"Sin"や"Cos"のように大文字で始まる形になっている場合にAffineTreeVisitorやIntervalTreeVisitorが対応できていないようだったので、必ず最初に小文字にしてから比較するようにしました。