### PR TITLE
Fix warning for vars_to_approximate

### DIFF
--- a/src/core/symbolic_simulate.cpp
+++ b/src/core/symbolic_simulate.cpp
@@ -145,7 +145,7 @@ void add_vars_from_string(string vars_list_string, set<string> &set_to_add,
   string buffer;
   while (std::getline(sstr, buffer, ',')) {
     trim_front_and_behind_space(buffer);
-    regex re("^\l[\l\d]*'*$");
+    regex re(R"(^[a-z][a-z\d]*'*$)");
     smatch match;
     if (!regex_search(buffer, match, re)) {
       cout << warning_prefix << " warning : \"" << buffer


### PR DESCRIPTION
vars_to_approximateに有効な変数名を指定しても警告メッセージが出るようになっていたので、修正しました
（boost::regexからstd::regexに変更した際に利用可能な文字クラス名が変わったようです）