### PR TITLE
fix: epsilonモードが不要な場合分けで失敗するケースを救済

### DIFF
--- a/src/simulator/PhaseSimulator.cpp
+++ b/src/simulator/PhaseSimulator.cpp
@@ -1859,6 +1859,12 @@ void PhaseSimulator::make_next_todo(phase_result_sptr_t &phase) {
                                        entry.parameter_constraint);
                   }
                   f_result = reduce_unsuitable_case(f_result, backend_, phase);
+                  if (f_result.size() == 0) {
+                    HYDLA_LOGGER_DEBUG(
+                        "#epsilon: No suitable case on this branch");
+                    continue;
+                  }
+
                   for (auto entry : time_result) {
                     HYDLA_LOGGER_DEBUG("#epsilon DC after : ",
                                        entry.parameter_constraint);


### PR DESCRIPTION
## 背景
`billiards.hydla` で以下のエラーが発生。
```sh
hylagi examples/epsilon/billiards.hydla
error : @PhaseSimulator.cpp 1868 assertion failure: f_result.size() == 1
```
<details>
<summary>エラー詳細</summary>
 hylagi examples/epsilon/billiards.hydla
error : @PhaseSimulator.cpp 1868 assertion failure: f_result.size() == 1

------ Result of Simulation ------
---------parameter condition(global)---------
p[eps, 0, 1]    : (0, inf)
---------Case 1---------
---------1---------
---------PP 1---------
unadopted modules: {}
positive        :
negative        :
t       : 0
Limit(t)        : 0
eps     : p[eps, 0, 1]
x1      : eps
x2      : 0
x3      : 0
x4      : 0
y1      : 0
y2      : 3
y3      : 6
y4      : 9
eps'    : 0
x1'     : 0
x2'     : 0
x3'     : 0
x4'     : 0
y1'     : 10
y2'     : 0
y3'     : 0
y4'     : 0
x1''    : 0
x2''    : 0
x3''    : 0
x4''    : 0
y1''    : 0
y2''    : 0
y3''    : 0
y4''    : 0
Limit(eps)        : 0
Limit(x1)         : 0
Limit(x2)         : 0
Limit(x3)         : 0
Limit(x4)         : 0
Limit(y1)         : 0
Limit(y2)         : 3
Limit(y3)         : 6
Limit(y4)         : 9
Limit(eps')       : 0
Limit(x1')        : 0
Limit(x2')        : 0
Limit(x3')        : 0
Limit(x4')        : 0
Limit(y1')        : 10
Limit(y2')        : 0
Limit(y3')        : 0
Limit(y4')        : 0
Limit(x1'')       : 0
Limit(x2'')       : 0
Limit(x3'')       : 0
Limit(x4'')       : 0
Limit(y1'')       : 0
Limit(y2'')       : 0
Limit(y3'')       : 0
Limit(y4'')       : 0
---------IP 2---------
unadopted modules: {}
positive        :
negative        :
t       : 0->(3+(-1)*(4+(-1)*p[eps, 0, 1]^2)^(1/2))*1/10
Limit(t)        : 0->1/10
eps     : p[eps, 0, 1]
x1      : p[eps, 0, 1]
x2      : 0
x3      : 0
x4      : 0
y1      : 10*t
y2      : 3
y3      : 6
y4      : 9
eps'    : 0
x1'     : 0
x2'     : 0
x3'     : 0
x4'     : 0
y1'     : 10
y2'     : 0
y3'     : 0
y4'     : 0
x1''    : 0
x2''    : 0
x3''    : 0
x4''    : 0
y1''    : 0
y2''    : 0
y3''    : 0
y4''    : 0
Limit(eps)        : 0
Limit(x1)         : 0
Limit(x2)         : 0
Limit(x3)         : 0
Limit(x4)         : 0
Limit(y1)         : 10*t
Limit(y2)         : 3
Limit(y3)         : 6
Limit(y4)         : 9
Limit(eps')       : 0
Limit(x1')        : 0
Limit(x2')        : 0
Limit(x3')        : 0
Limit(x4')        : 0
Limit(y1')        : 10
Limit(y2')        : 0
Limit(y3')        : 0
Limit(y4')        : 0
Limit(x1'')       : 0
Limit(x2'')       : 0
Limit(x3'')       : 0
Limit(x4'')       : 0
Limit(y1'')       : 0
Limit(y2'')       : 0
Limit(y3'')       : 0
Limit(y4'')       : 0
---------2---------
---------PP 3---------
unadopted modules: {}
positive        : (x1--x2-)^2+(y1--y2-)^2=4=>x1'=(x1'-*(y2--y1-)^2+(y2'--y1'-)*(x2--x1-)*(y2--y1-)+x2'-*(x2--x1-)^2)/4&y1'=(y1'-*(x2--x1-)^2+(x2'--x1'-)*(y2--y1-)*(x2--x1-)+y2'-*(y2--y1-)^2)/4&x2'=(x2'-*(y1--y2-)^2+(y1'--y2'-)*(x1--x2-)*(y1--y2-)+x1'-*(x1--x2-)^2)/4&y2'=(y2'-*(x1--x2-)^2+(x1'--x2'-)*(y1--y2-)*(x1--x2-)+y1'-*(y1--y2-)^2)/4
negative        :
t       : 1/10
Limit(t)        : 1/10
eps     : p[eps, 0, 1]
x1      : p[eps, 0, 1]
x2      : 0
x3      : 0
x4      : 0
y1      : 3+(-1)*(4+(-1)*p[eps, 0, 1]^2)^(1/2)
y2      : 3
y3      : 6
y4      : 9
eps'    : 0
x1'     : 0
x2'     : 0
x3'     : 0
x4'     : 0
y1'     : 10
y2'     : 0
y3'     : 0
y4'     : 0
x1''    : 0
x2''    : 0
x3''    : 0
x4''    : 0
y1''    : 0
y2''    : 0
y3''    : 0
y4''    : 0
Limit(eps)        : 0
Limit(x1)         : 0
Limit(x2)         : 0
Limit(x3)         : 0
Limit(x4)         : 0
Limit(y1)         : 1
Limit(y2)         : 3
Limit(y3)         : 6
Limit(y4)         : 9
Limit(eps')       : 0
Limit(x1')        : 0
Limit(x2')        : 0
Limit(x3')        : 0
Limit(x4')        : 0
Limit(y1')        : 10
Limit(y2')        : 0
Limit(y3')        : 0
Limit(y4')        : 0
Limit(x1'')       : 0
Limit(x2'')       : 0
Limit(x3'')       : 0
Limit(x4'')       : 0
Limit(y1'')       : 0
Limit(y2'')       : 0
Limit(y3'')       : 0
Limit(y4'')       : 0
---------IP 7---------
unadopted modules: {}
positive        :
negative        : (x1--x2-)^2+(y1--y2-)^2=4=>x1'=(x1'-*(y2--y1-)^2+(y2'--y1'-)*(x2--x1-)*(y2--y1-)+x2'-*(x2--x1-)^2)/4&y1'=(y1'-*(x2--x1-)^2+(x2'--x1'-)*(y2--y1-)*(x2--x1-)+y2'-*(y2--y1-)^2)/4&x2'=(x2'-*(y1--y2-)^2+(y1'--y2'-)*(x1--x2-)*(y1--y2-)+x1'-*(x1--x2-)^2)/4&y2'=(y2'-*(x1--x2-)^2+(x1'--x2'-)*(y1--y2-)*(x1--x2-)+y1'-*(y1--y2-)^2)/4
t       : 1/10->3/10
Limit(t)        : 1/10->3/10
eps     : p[eps, 0, 1]
x1      : p[eps, 0, 1]
x2      : 0
x3      : 0
x4      : 0
y1      : 10*t
y2      : 3
y3      : 6
y4      : 9
eps'    : 0
x1'     : 0
x2'     : 0
x3'     : 0
x4'     : 0
y1'     : 10
y2'     : 0
y3'     : 0
y4'     : 0
x1''    : 0
x2''    : 0
x3''    : 0
x4''    : 0
y1''    : 0
y2''    : 0
y3''    : 0
y4''    : 0
Limit(eps)        : 0
Limit(x1)         : 0
Limit(x2)         : 0
Limit(x3)         : 0
Limit(x4)         : 0
Limit(y1)         : 10*t
Limit(y2)         : 3
Limit(y3)         : 6
Limit(y4)         : 9
Limit(eps')       : 0
Limit(x1')        : 0
Limit(x2')        : 0
Limit(x3')        : 0
Limit(x4')        : 0
Limit(y1')        : 10
Limit(y2')        : 0
Limit(y3')        : 0
Limit(y4')        : 0
Limit(x1'')       : 0
Limit(x2'')       : 0
Limit(x3'')       : 0
Limit(x4'')       : 0
Limit(y1'')       : 0
Limit(y2'')       : 0
Limit(y3'')       : 0
Limit(y4'')       : 0
---------parameter condition(Case1)---------
p[eps, 0, 1]    : 2
# unknown error occured

---------Case 2---------
---------1---------
---------PP 1---------
unadopted modules: {}
positive        :
negative        :
t       : 0
Limit(t)        : 0
eps     : p[eps, 0, 1]
x1      : eps
x2      : 0
x3      : 0
x4      : 0
y1      : 0
y2      : 3
y3      : 6
y4      : 9
eps'    : 0
x1'     : 0
x2'     : 0
x3'     : 0
x4'     : 0
y1'     : 10
y2'     : 0
y3'     : 0
y4'     : 0
x1''    : 0
x2''    : 0
x3''    : 0
x4''    : 0
y1''    : 0
y2''    : 0
y3''    : 0
y4''    : 0
Limit(eps)        : 0
Limit(x1)         : 0
Limit(x2)         : 0
Limit(x3)         : 0
Limit(x4)         : 0
Limit(y1)         : 0
Limit(y2)         : 3
Limit(y3)         : 6
Limit(y4)         : 9
Limit(eps')       : 0
Limit(x1')        : 0
Limit(x2')        : 0
Limit(x3')        : 0
Limit(x4')        : 0
Limit(y1')        : 10
Limit(y2')        : 0
Limit(y3')        : 0
Limit(y4')        : 0
Limit(x1'')       : 0
Limit(x2'')       : 0
Limit(x3'')       : 0
Limit(x4'')       : 0
Limit(y1'')       : 0
Limit(y2'')       : 0
Limit(y3'')       : 0
Limit(y4'')       : 0
---------IP 4---------
unadopted modules: {}
positive        :
negative        :
t       : 0->Infinity
Limit(t)        + : 0->Infinity
Limit(t)        - : 0->Infinity
eps     : p[eps, 0, 1]
x1      : p[eps, 0, 1]
x2      : 0
x3      : 0
x4      : 0
y1      : 10*t
y2      : 3
y3      : 6
y4      : 9
eps'    : 0
x1'     : 0
x2'     : 0
x3'     : 0
x4'     : 0
y1'     : 10
y2'     : 0
y3'     : 0
y4'     : 0
x1''    : 0
x2''    : 0
x3''    : 0
x4''    : 0
y1''    : 0
y2''    : 0
y3''    : 0
y4''    : 0
Limit(eps)        : 0
Limit(x1)         : 0
Limit(x2)         : 0
Limit(x3)         : 0
Limit(x4)         : 0
Limit(y1)         : 10*t
Limit(y2)         : 3
Limit(y3)         : 6
Limit(y4)         : 9
Limit(eps')       : 0
Limit(x1')        : 0
Limit(x2')        : 0
Limit(x3')        : 0
Limit(x4')        : 0
Limit(y1')        : 10
Limit(y2')        : 0
Limit(y3')        : 0
Limit(y4')        : 0
Limit(x1'')       : 0
Limit(x2'')       : 0
Limit(x3'')       : 0
Limit(x4'')       : 0
Limit(y1'')       : 0
Limit(y2'')       : 0
Limit(y3'')       : 0
Limit(y4'')       : 0
---------parameter condition(Case2)---------
p[eps, 0, 1]    : (2, inf)
# time reached limit



Simulation Time : 2.392152 s
Finish Time : 2.405551 s
</details>

原因は`eps`に`0<eps<inf` の制約がかかっている部分の特に`eps<inf` で、これのせいで不必要な場合分けが発生し、epsの極限を取ったときにassertionのエラーを吐いて失敗する。

このケースの不要な場合分けで発生した制約の矛盾は正常であり、そこで枝切りがされれば良いはず。
assertに引っ掛けずにcontinueするようにした。

他のepsilonの例も正しく動くことを確認済み