### PR TITLE
fix: examples/interval のコマンド修正

### DIFF
--- a/examples/interval/bouncing_particle_v_slope.hydla
+++ b/examples/interval/bouncing_particle_v_slope.hydla
@@ -22,4 +22,6 @@ BOUNCE_PLUS <=> [](y- = tan(s) * x- =>
 
 INIT, A << (BOUNCE_PLUS,BOUNCE_MINUS).
 
-//#hylagi -p10 --fnd --finterval --fdump_in_progress --guards_to_interval_newton y-=tan[s]*x-,y-=(-tan[s])*x-
+//#hylagi -p10 --fnd --finterval --guards_to_interval_newton y-=Tan[s]*x-,y-=-Tan[s]*x-
+//#hylagi -p10 --fnd --finterval --guards_to_interval_newton y-=Tan[s]*x-,y-=-Tan[s]*x- --faffine
+//#hylagi -p5 --fnd 

--- a/examples/interval/circle.hydla
+++ b/examples/interval/circle.hydla
@@ -9,4 +9,6 @@ BOUNCE <=> []((x-)^2 + (y-)^2 = 1 => cont = 0 &
 ).
 INIT, RUN, [](cont = 1) << BOUNCE.
 
-//#hylagi -p15 --fnd --guards_to_interval_newton x-^2+y-^2=1 --finterval --fstep_by_step --approximation_step 1 --vars_to_approximate x,y,x',y'
+//#hylagi -p15 --guards_to_interval_newton x-^2+y-^2=1 --finterval --fstep_by_step --approximation_step 1 --vars_to_approximate x,y,x',y' 
+//#hylagi -p15 --guards_to_interval_newton x-^2+y-^2=1 --finterval --fstep_by_step --approximation_step 1 --vars_to_approximate x,y,x',y' --faffine 
+

--- a/examples/interval/half_circle.hydla
+++ b/examples/interval/half_circle.hydla
@@ -5,4 +5,4 @@ CONSTDIR <=> [](c' = 0).
 
 INIT, CONSTDIR << BOUNCE, CIRCLE.
 
-//#hylagi -p 30 --fnd --finterval --approximation_step 1 --vars_to_approximate x,y
+//#hylagi -p 30 --fnd --finterval --approximation_step 1 --vars_to_approximate x,y --guards_to_interval_newton x-=y-

--- a/examples/interval/planet_tunnel_easy.hydla
+++ b/examples/interval/planet_tunnel_easy.hydla
@@ -7,3 +7,4 @@ FORCE3 <=> [](x- < -1 => x''=4/3*Pi*r*g).
 INIT(0.5), CONST, FORCE1 << (FORCE2, FORCE3).
 
 //#hylagi -p18 --finterval --fnd --approximation_step 1 --vars_to_approximate x' --guards_to_interval_newton x->1,x-<-1
+//This program cannot be executed using the above command.Currently, the executable commands for this program are unknown.

--- a/examples/interval/simplified_inverted_pendulum.hydla
+++ b/examples/interval/simplified_inverted_pendulum.hydla
@@ -16,4 +16,6 @@ LAW(1,1,1,10,0),
 SCONST << (SR, SL),
 FORCE(1, 15), FORCE(2, -15), FORCE(0, 0).
 
-// #hylagi -p10 --fignore_warnings --finterval --guards_to_interval_newton angle-=threshold,angle-=-threshold --fdump_in_progress --fstep_by_step
+//#hylagi -p9 --fignore_warnings --finterval --guards_to_interval_newton angle-=threshold,angle-=-threshold --fdump_in_progress --fstep_by_step
+//#hylagi -p10 --fignore_warnings --finterval --guards_to_interval_newton angle-=threshold,angle-=-threshold --fdump_in_progress --fstep_by_step --faffine 
+//#hylagi -p10 --fignore_warnings 

--- a/examples/interval/trampoline.hydla
+++ b/examples/interval/trampoline.hydla
@@ -3,3 +3,7 @@ FALL <=> [](x'' = -m*g).
 TRAMPOLINE <=> [](x < 0 => x'' = -k*x - m*g).
 
 INIT, FALL<<TRAMPOLINE.
+
+//#hylagi -p7 --finterval --fstep_by_step --guards_to_interval_newton x<0 --vars_to_approximate x x' --approximation_step 1
+//#hylagi -p5 --finterval --fstep_by_step --guards_to_interval_newton x<0 --vars_to_approximate x x' --approximation_step 1 --faffine
+//#hylagi -p3

--- a/examples/interval/two_tanks.hydla
+++ b/examples/interval/two_tanks.hydla
@@ -11,4 +11,5 @@ X2 <=> []((v2 = 0 => x2' = x1) & (v2 = 1 => x2' = x1 - x2 - 5)).
 
 INIT, (V1_CONST, V2_CONST) << (V1_OFF2ON, V1_ON2OFF, V2_OFF2ON, V2_ON2OFF), X1, X2.
 
-//#hylagi --fnd  --finterval --guards_to_interval_newton x1-=-1,x1-=1,x2-=1,x2-=0 --fstep_by_step -p 60
+//#hylagi --fnd  --finterval --guards_to_interval_newton x1-=-1,x1-=1,x2-=1,x2-=0 --fstep_by_step -p21
+//#hylagi --fnd  --finterval --guards_to_interval_newton x1-=-1,x1-=1,x2-=1,x2-=0 --fstep_by_step -p60 --faffine 


### PR DESCRIPTION
examples/interval にあるhydlaプログラム内のコマンドをエラーが起きないように修正. 
また, 複数のオプションで実行可能なプログラムにはそのコマンドも追加。フェーズ数は実行可能ぎりぎりに調整。