### PR TITLE
fix README, CI and Makefile

### DIFF
--- a/.github/actions/setup-ubuntu/action.yaml
+++ b/.github/actions/setup-ubuntu/action.yaml
@@ -7,9 +7,9 @@ runs:
         clang++ --version | head -n 1
         python3 --version
       shell: bash
-    - name: install boost
+    - name: install boost and uuid
       run: |
-        sudo apt install libboost-all-dev
+        sudo apt install libboost-all-dev uuid-dev
       shell: bash
     - name: install mathematica
       run: |

--- a/.github/workflows/build-on-ubuntu.yaml
+++ b/.github/workflows/build-on-ubuntu.yaml
@@ -8,33 +8,33 @@ on:
     branches:
       - '*'
 jobs:
-  ubuntu20_04-clang10_0_0-python3_8_5:
-    runs-on: ubuntu-20.04
+  ubuntu22_04-clang:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-ubuntu
     - name: build
       run: |
         make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/14.0 CC=clang CXX=clang++
-  ubuntu20_04-gcc9_3_0-python3_8_5:
-    runs-on: ubuntu-20.04
+  ubuntu22_04-gcc:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-ubuntu
     - name: build
       run: |
         make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/14.0 CC=gcc CXX=g++
-
-  ubuntu22_04-clang14_0_0-python3_10_6:
-    runs-on: ubuntu-22.04
+  
+  ubuntu24_04-clang:
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-ubuntu
     - name: build
       run: |
         make -j 4 MATHPATH=/usr/local/Wolfram/WolframEngine/14.0 CC=clang CXX=clang++
-  ubuntu22_04-gcc11_3_0-python3_10_6:
-    runs-on: ubuntu-22.04
+  ubuntu24_04-gcc:
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-ubuntu

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ src_directory := src
 UNAME := $(shell uname)
 .PHONY : all
 all: $(src_directory)
-	@make math-check
+	$(MAKE) math-check
 	@mkdir -p bin && cd src && $(MAKE)
 	@printf "%s \033[32m%s\033[m\n" "build" "succeeded"
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,19 @@ You can also use [webHydLa](http://webhydla.ueda.info.waseda.ac.jp) to run HydLa
 - Python
 - Wolfram system (Mathematica, or WolframEngine)
 
-### Ubuntu 22.04 with Clang
+### Ubuntu 24.04 with GCC
 
-1. Install required packages
-   ```bash
-   sudo apt update && sudo apt install -y git make clang libboost-all-dev uuid-dev
+1. Install required packages.
+   ```sh
+   sudo apt update
+   sudo apt install -y git make g++ libboost-all-dev uuid-dev
    ```
-1. Install and activate Mathematica  
+1. Install and activate Mathematica.  
    If you don't have Wolfram's license, you can use [Free Wolfram Engine for Developers](https://www.wolfram.com/engine/index.php).
-1. Set `$MATHPATH` (see **What is `MATHPATH`?** below)  
-   e.g., Wolfram Engine 14.0
-   ```bash
-   echo "export MATHPATH='/usr/local/Wolfram/WolframEngine/14.0'" >> ~/.bashrc
+1. Set `$MATHPATH` (see **What is `MATHPATH`?** below).  
+   e.g., Wolfram Engine 14.2
+   ```sh
+   echo "export MATHPATH='/usr/local/Wolfram/WolframEngine/14.2'" >> ~/.bashrc
    source ~/.bashrc   # or restart the terminal
    ```
 1. Library settings
@@ -41,19 +42,19 @@ You can also use [webHydLa](http://webhydla.ueda.info.waseda.ac.jp) to run HydLa
    echo "$MATHPATH/SystemFiles/Links/WSTP/DeveloperKit/Linux-x86-64/CompilerAdditions" | sudo tee /etc/ld.so.conf.d/wstp.conf
    sudo ldconfig
    ```
-1. Build HyLaGI
+1. Build HyLaGI.
    ```bash
    git clone https://github.com/HydLa/HyLaGI.git
    cd HyLaGI
    make -j 4 MATHPATH=$MATHPATH
-   echo "export PATH='$PATH:$MATHPATH/Executables:$(pwd)/bin'" >> ~/.bashrc
+   echo "export PATH='\$PATH:$MATHPATH/Executables:$(pwd)/bin'" >> ~/.bashrc
    source ~/.bashrc   # or restart the terminal
    ```
    Then, you can use `hylagi` command. For example:
    ```bash
    hylagi -p 6 examples/bouncing_particle.hydla
    ```
-1. Run tests  
+1. Run tests.  
    By default, `make test` runs tests sequentially.  
    If you want it to run in parallel, you can set the number of threads as follows:
    ```bash
@@ -66,15 +67,17 @@ You can also use [webHydLa](http://webhydla.ueda.info.waseda.ac.jp) to run HydLa
 HyLaGI supports several environments.
 
 - OS: Ubuntu and macOS
-- C++ compiler: Clang (default) and GCC
+- C++ compiler: Clang and GCC (default)
 
 <details>
 <summary>Build confirmed environment</summary>
 
-- Ubuntu 20.04.1, GCC 9.3.0, Python 3.8.5
-- Ubuntu 20.04.1, Clang 10.0.0, Python 3.8.5
+<!-- - Ubuntu 20.04.1, GCC 9.3.0, Python 3.8.5
+- Ubuntu 20.04.1, Clang 10.0.0, Python 3.8.5 -->
 - Ubuntu 22.04.1, GCC 11.3.0, Python 3.10.6
 - Ubuntu 22.04.1, Clang 14.0.0, Python 3.10.6
+- Ubuntu 24.04.2, GCC 13.3.0, Python 3.12.3
+- Ubuntu 24.04.2, Clang 18.1.3, Python 3.12.3
 - macOS 10.15.7, Apple clang 12.0.0, Python 3.6.9
 - macOS 10.15.7, Apple clang 12.0.0, Python 3.8.5
 </details>
@@ -84,10 +87,16 @@ HyLaGI supports several environments.
 To build several environments,
 you can set environment variables when you exec `make`.  
 
-#### Using GCC:
+#### Forcing to use GCC:
 
 ```
 make -j 4 CC=gcc CXX=g++
+```
+
+#### Forcing to use clang:
+
+```
+make -j 4 CC=clang CXX=clang++
 ```
 
 #### When using Python3 with `python` command:
@@ -126,5 +135,22 @@ It uses WSTP communication with the `math` command to make the call.
 If you see this error, please make sure that the `math` command is installed and in the path.
 If the `math` command does not exist (as confirmed when using WolframEngine on MacOS), create a symbolic link to `WolframKernel` named math.
 
+### For users who have both clang and gcc installed (Ubuntu)
+Where `gcc` and `clang` are both installed, Executing `make` with `clang` may cause errors claiming that some basic libraries are not found. Use `g++` instead, or install a specific version of the standard library in the following way.
+
+1. Run `clang -v` and check the dependent GCC version written at the end of the line: `Selected GCC installation`. (hereafter `[version]`)
+2. Install GNU libstdc++ of the version checked above.
+```sh
+apt install libstdc++-[version]-dev
+```
+or install the whole `g++` compiler of the version.
+```sh
+apt install g++-[version]
+```
+3. Run `make` to build.
+```sh
+make CC=clang CXX=clang++
+```
+
 ## CI
-CI supports only build (not include testing examples). If you want to test them, do ``` make test ``` after building HyLaGI on your terminal.
+CI supports only build (not include testing examples). If you want to test them, do ``` make test ``` after building HyLaGI on your terminal. See `system_test/README.md` for details.

--- a/system_test/README.md
+++ b/system_test/README.md
@@ -1,8 +1,8 @@
 ## Usage
 
 /HyLaGI で`make test`すると統合テストが走る．
-ただしデフォルトでは約 40 並列でテストを行うので，
-ローカルで行う場合は`fnum=2 make test`などとする
+ただしデフォルトでは逐次でテストを行うので，
+並列で行う場合は`make test fnum=2`などとする．ただし，MathematicaやWolfram Engine等のライセンスによって同時実行数が制限されている場合があるため注意．
 
 ## Files
 - system_test.sh:  


### PR DESCRIPTION
- READMEのビルド手順をUbuntu 24.04 with GCCに更新
  + clangとgcc双方が入っている場合に生じるstdlibバージョン不整合に関する説明を追加
- ビルド確認済み環境をUbuntu 20 and 22からUbuntu 22 and 24に更新
  + 同様にCIも更新
- make -j 実行時のwarningを修正